### PR TITLE
Replace DateTime.ToShortDate usage with .ToString()

### DIFF
--- a/Fortnox.NET.Tests/Fortnox.NET.Tests/AccountTests.cs
+++ b/Fortnox.NET.Tests/Fortnox.NET.Tests/AccountTests.cs
@@ -30,7 +30,7 @@ namespace FortnoxNET.Tests
                               SearchParameters = new Dictionary<AccountSearchParameters, object>() {{AccountSearchParameters.SRU, 1}}
                           };
             
-            request.SearchParameters.Add(AccountSearchParameters.FinancialYearDate, DateTime.Parse("2016-01-01").ToShortDateString());
+            request.SearchParameters.Add(AccountSearchParameters.FinancialYearDate, DateTime.Parse("2016-01-01").ToString("yyyy-MM-dd"));
 
             var accountList = await AccountService.GetAccountsAsync(request);
 
@@ -41,7 +41,7 @@ namespace FortnoxNET.Tests
         public void GetCustomerInvoicesPaginationTest()
         {
             var request = new AccountListRequest(this.connectionSettings.AccessToken, this.connectionSettings.ClientSecret);
-            request.SearchParameters.Add(AccountSearchParameters.FinancialYearDate, DateTime.UtcNow.ToShortDateString());
+            request.SearchParameters.Add(AccountSearchParameters.FinancialYearDate, DateTime.UtcNow.ToString("yyyy-MM-dd"));
             request.Limit = 50;
             request.Page = 1;
             

--- a/Fortnox.NET.Tests/Fortnox.NET.Tests/AssetsTest.cs
+++ b/Fortnox.NET.Tests/Fortnox.NET.Tests/AssetsTest.cs
@@ -44,9 +44,9 @@ namespace FortnoxNET.Tests
                 DepreciationMethod = "0",
                 AcquisitionValue = 13000,
                 DepreciateToResidualValue = 1300,
-                AcquisitionDate = currentDate.ToShortDateString(),
-                AcquisitionStart = currentDate.AddMonths(1).ToShortDateString(),
-                DepreciationFinal = currentDate.AddYears(1).ToShortDateString(),
+                AcquisitionDate = currentDate.ToString("yyyy-MM-dd"),
+                AcquisitionStart = currentDate.AddMonths(1).ToString("yyyy-MM-dd"),
+                DepreciationFinal = currentDate.AddYears(1).ToString("yyyy-MM-dd"),
             };
 
             var request = new FortnoxApiRequest(this.connectionSettings.AccessToken, this.connectionSettings.ClientSecret);

--- a/Fortnox.NET.Tests/Fortnox.NET.Tests/AttendanceTransactionTests.cs
+++ b/Fortnox.NET.Tests/Fortnox.NET.Tests/AttendanceTransactionTests.cs
@@ -47,7 +47,7 @@ namespace FortnoxNET.Tests
 
             Assert.AreEqual(2, response.Hours);
 
-            await AttendanceTransactionService.DeleteAttendanceTransactionAsync(request, "1593082874", today.ToShortDateString(), "TID");
+            await AttendanceTransactionService.DeleteAttendanceTransactionAsync(request, "1593082874", today.ToString("yyyy-MM-dd"), "TID");
         }
 
         //[TestMethod]

--- a/Fortnox.NET.Tests/Fortnox.NET.Tests/ContractTests.cs
+++ b/Fortnox.NET.Tests/Fortnox.NET.Tests/ContractTests.cs
@@ -45,9 +45,9 @@ namespace FortnoxNET.Tests
                     { 
                         new InvoiceRow { ArticleNumber = "1", DeliveredQuantity = "1000", AccountNumber = 3001 } 
                     },
-                    ContractDate = DateTime.Now.ToShortDateString(),
-                    PeriodStart = DateTime.Now.AddDays(1).ToShortDateString(),
-                    PeriodEnd = new DateTime(DateTime.Now.Year, DateTime.Now.Month+1, 1).AddDays(-1).ToShortDateString(),
+                    ContractDate = DateTime.Now.ToString("yyyy-MM-dd"),
+                    PeriodStart = DateTime.Now.AddDays(1).ToString("yyyy-MM-dd"),
+                    PeriodEnd = new DateTime(DateTime.Now.Year, DateTime.Now.Month+1, 1).AddDays(-1).ToString("yyyy-MM-dd"),
                 }).GetAwaiter().GetResult();
 
             Assert.AreEqual("1", response.CustomerNumber);

--- a/Fortnox.NET.Tests/Fortnox.NET.Tests/CustomerTests.cs
+++ b/Fortnox.NET.Tests/Fortnox.NET.Tests/CustomerTests.cs
@@ -93,7 +93,7 @@ namespace FortnoxNET.Tests
         public void CreateCustomer()
         {
             var request = new FortnoxApiRequest(this.connectionSettings.AccessToken, this.connectionSettings.ClientSecret);
-            var customerName = $"TestKund {DateTime.Now.ToShortDateString()}";
+            var customerName = $"TestKund {DateTime.Now.ToString("yyyy-MM-dd")}";
             var response = CustomerService.CreateCustomerAsync(request, 
                 new Customer 
                 { 

--- a/Fortnox.NET.Tests/Fortnox.NET.Tests/EmployeeTests.cs
+++ b/Fortnox.NET.Tests/Fortnox.NET.Tests/EmployeeTests.cs
@@ -48,7 +48,7 @@ namespace FortnoxNET.Tests
         public void CreateEmployee()
         {
             var request = new FortnoxApiRequest(this.connectionSettings.AccessToken, this.connectionSettings.ClientSecret);
-            var employeeName = $"TestAnställd {DateTime.Now.ToShortDateString()}";
+            var employeeName = $"TestAnställd {DateTime.Now.ToString("yyyy-MM-dd")}";
             
             var response = EmployeeService.CreateEmployeeAsync(request, 
                 new Employee 

--- a/Fortnox.NET.Tests/Fortnox.NET.Tests/ProjectTests.cs
+++ b/Fortnox.NET.Tests/Fortnox.NET.Tests/ProjectTests.cs
@@ -49,7 +49,7 @@ namespace FortnoxNET.Tests
         {
             var request = new ProjectListRequest(this.connectionSettings.AccessToken, this.connectionSettings.ClientSecret)
             {
-                SearchParameters = new Dictionary<ProjectSearchParameters, object> {{ProjectSearchParameters.LastModified, DateTime.UtcNow.ToShortDateString()}}
+                SearchParameters = new Dictionary<ProjectSearchParameters, object> {{ProjectSearchParameters.LastModified, DateTime.UtcNow.ToString("yyyy-MM-dd")}}
             };
 
             var projects = ProjectService.GetProjectsAsync(request).GetAwaiter().GetResult();

--- a/Fortnox.NET.Tests/Fortnox.NET.Tests/SupplierInvoiceTests.cs
+++ b/Fortnox.NET.Tests/Fortnox.NET.Tests/SupplierInvoiceTests.cs
@@ -42,7 +42,7 @@ namespace FortnoxNET.Tests
                                                      {SupplierInvoiceSearchParameters.FromDate, "2018-02-18"}, {SupplierInvoiceSearchParameters.ToDate, "2018-12-31"},
                                                  }
                           };
-            request.SearchParameters[SupplierInvoiceSearchParameters.FinancialYearDate] = DateTime.UtcNow.AddYears(-1).ToShortDateString();
+            request.SearchParameters[SupplierInvoiceSearchParameters.FinancialYearDate] = DateTime.UtcNow.AddYears(-1).ToString("yyyy-MM-dd");
 
             var invoiceList = await SupplierInvoiceService.GetSupplierInvoicesAsync(request);
 

--- a/Fortnox.NET.Tests/Fortnox.NET.Tests/UnitTests.cs
+++ b/Fortnox.NET.Tests/Fortnox.NET.Tests/UnitTests.cs
@@ -60,7 +60,7 @@ namespace FortnoxNET.Tests
         {
             var request = new UnitListRequest(this.connectionSettings.AccessToken, this.connectionSettings.ClientSecret)
                           {
-                              SearchParameters = new Dictionary<UnitSearchParameters, object> {{UnitSearchParameters.LastModified, DateTime.Today.ToShortDateString()}}
+                              SearchParameters = new Dictionary<UnitSearchParameters, object> {{UnitSearchParameters.LastModified, DateTime.Today.ToString("yyyy-MM-dd")}}
                           };
 
             var units = UnitService.GetUnitsAsync(request).GetAwaiter().GetResult();

--- a/Fortnox.NET.Tests/Fortnox.NET.Tests/VoucherTests.cs
+++ b/Fortnox.NET.Tests/Fortnox.NET.Tests/VoucherTests.cs
@@ -16,7 +16,7 @@ namespace FortnoxNET.Tests
         public async Task GetVouchersTest()
         {
             var request = new VoucherListRequest(this.connectionSettings.AccessToken, this.connectionSettings.ClientSecret);
-            request.SearchParameters[VoucherSearchParameters.FinancialYearDate] = DateTime.UtcNow.ToShortDateString();
+            request.SearchParameters[VoucherSearchParameters.FinancialYearDate] = DateTime.UtcNow.ToString("yyyy-MM-dd");
             var voucherList = await VoucherService.GetVouchersAsync(request);
 
             Assert.IsTrue(voucherList.Data.ToList().Count > 0);
@@ -26,7 +26,7 @@ namespace FortnoxNET.Tests
         public async Task GetVouchersFromDateToDateTest()
         {
             var request = new VoucherListRequest(this.connectionSettings.AccessToken, this.connectionSettings.ClientSecret);
-            request.SearchParameters[VoucherSearchParameters.FinancialYearDate] = DateTime.UtcNow.ToShortDateString();
+            request.SearchParameters[VoucherSearchParameters.FinancialYearDate] = DateTime.UtcNow.ToString("yyyy-MM-dd");
 
             var voucherList = await VoucherService.GetVouchersAsync(request);
 


### PR DESCRIPTION
Unit tests were failing on any computer using English as DateTime.ToShortDate() outputs the date as mm/DD/yyyy. 