### PR TITLE
Initial fortnox websocket implementation.

### DIFF
--- a/Fortnox.NET.Tests/Fortnox.NET.Tests/WebSocket/FortnoxWebSocketClientTest.cs
+++ b/Fortnox.NET.Tests/Fortnox.NET.Tests/WebSocket/FortnoxWebSocketClientTest.cs
@@ -1,0 +1,262 @@
+﻿using FortnoxNET.Communication;
+using FortnoxNET.Communication.Order;
+using FortnoxNET.Models.Article;
+using FortnoxNET.Models.Order;
+using FortnoxNET.Services;
+using FortnoxNET.WebSockets;
+using FortnoxNET.WebSockets.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using System;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FortnoxNET.Tests.WebSocket
+{
+    [TestClass]
+    public class FortnoxWebSocketClientTest : TestBase
+    {
+        private const int DEFAULT_BUFFER_SIZE = 2048;
+
+        [TestMethod]
+        public async Task CanListenUsingEnumerable()
+        {
+            var client = new FortnoxWebSocketClient(this.connectionSettings.AccessToken, this.connectionSettings.ClientSecret)
+                .AddTopic(WebSocketTopic.Articles);
+
+            var listeningTask = new Task(async () =>
+            {
+                try
+                {
+                    (await client.Connect()).Listen(async (socket) =>
+                    {
+                        foreach (var response in client.GetNextEvent(socket))
+                        {
+                            if (response != null)
+                            {
+                                Assert.IsTrue(response.Topic == "articles");
+                                Assert.IsTrue(response.Type == "article-updated-v1");
+                                Assert.IsTrue(response.EntityId == "100370");
+
+                                return;
+                            }
+                        }
+                    }).GetAwaiter().GetResult();
+                }
+                catch (Exception e)
+                {
+                    Assert.Fail(e.Message);
+                }
+            }, TaskCreationOptions.LongRunning);
+            listeningTask.Start();
+
+            var updatedDescription = $"TestArtikel {DateTime.UtcNow}";
+            var article = new Article { Description = updatedDescription, ArticleNumber = "100370" };
+            var request = new FortnoxApiRequest(this.connectionSettings.AccessToken, this.connectionSettings.ClientSecret);
+            var updatedArticle = ArticleService.UpdateArticleAsync(request, article).GetAwaiter().GetResult();
+            Assert.AreEqual(updatedDescription, updatedArticle.Description);
+
+            await listeningTask;
+        }
+
+        [TestMethod]
+        public async Task CanConnectAndListen()
+        {
+            var client = await new FortnoxWebSocketClient(this.connectionSettings.AccessToken, this.connectionSettings.ClientSecret)
+                .AddTopic(WebSocketTopic.Articles)
+                .Connect();
+
+            var updatedDescription = $"TestArtikel {DateTime.UtcNow}";
+            var article = new Article { Description = updatedDescription, ArticleNumber = "100370" };
+            var request = new FortnoxApiRequest(this.connectionSettings.AccessToken, this.connectionSettings.ClientSecret);
+            var updatedArticle = ArticleService.UpdateArticleAsync(request, article).GetAwaiter().GetResult();
+            Assert.AreEqual(updatedDescription, updatedArticle.Description);
+
+            await client.Listen(async (socket) =>
+            {
+                var finished = false;
+                var resultString = "";
+                while (!finished)
+                {
+                    if (socket.State == WebSocketState.Open)
+                    {
+                        var buffer = new byte[DEFAULT_BUFFER_SIZE];
+                        var result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+                        if (result.MessageType == WebSocketMessageType.Close)
+                        {
+                            await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
+                            Assert.Fail("Socket closed unexpectedly.");
+                            return;
+                        }
+                        else
+                        {
+                            resultString += Encoding.ASCII.GetString(buffer);
+                            finished = result.EndOfMessage;
+                        }
+                    }
+                    else
+                    {
+                        Assert.Fail("Socket unexpectedly closed.");
+                    }
+                }
+
+                try
+                {
+                    var response = JsonConvert.DeserializeObject<WebSocketEvent>(resultString);
+                    Assert.IsTrue(response.Topic == "articles");
+                    Assert.IsTrue(response.Type == "article-updated-v1");
+                    Assert.IsTrue(response.EntityId == "100370");
+                }
+                catch (Exception e)
+                {
+                    throw e;
+                }
+
+                return;
+            });
+        }
+
+        [TestMethod]
+        public async Task CanListenInNonblockingThread()
+        {
+            var client = new FortnoxWebSocketClient(this.connectionSettings.AccessToken, this.connectionSettings.ClientSecret)
+                .AddTopic(WebSocketTopic.Articles);
+
+            var listeningTask = new Task(() => { WebsocketListenerHelper(client); }, TaskCreationOptions.LongRunning);
+            listeningTask.Start();
+
+            var updatedDescription = $"TestArtikel {DateTime.UtcNow}";
+            var article = new Article { Description = updatedDescription, ArticleNumber = "100370" };
+            var request = new FortnoxApiRequest(this.connectionSettings.AccessToken, this.connectionSettings.ClientSecret);
+            var updatedArticle = ArticleService.UpdateArticleAsync(request, article).GetAwaiter().GetResult();
+            Assert.AreEqual(updatedDescription, updatedArticle.Description);
+
+            await listeningTask;
+        }
+
+        public void WebsocketListenerHelper(FortnoxWebSocketClient client)
+        {
+            var task = new Task(async () =>
+            {
+                try
+                {
+                    (await client.Connect()).Listen(async (socket) =>
+                    {
+                        var buffer = new byte[DEFAULT_BUFFER_SIZE];
+                        while (socket.State == WebSocketState.Open)
+                        {
+                            var result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+                            if (result.MessageType == WebSocketMessageType.Close)
+                            {
+                                await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
+                                Assert.Fail("Socket closed unexpectedly.");
+                                return;
+                            }
+                            else
+                            {
+                                var response = JsonConvert.DeserializeObject<WebSocketEvent>(Encoding.ASCII.GetString(buffer));
+
+                                Assert.IsTrue(response.Topic == "articles");
+                                Assert.IsTrue(response.Type == "article-updated-v1");
+                                Assert.IsTrue(response.EntityId == "100370");
+
+                                return;
+                            }
+                        }
+                    }).GetAwaiter().GetResult();
+                }
+                catch (Exception e)
+                {
+                    Assert.Fail("");
+                }
+            }, TaskCreationOptions.LongRunning);
+
+            task.RunSynchronously();
+        }
+
+        [TestMethod]
+        public async Task CannotConnectTwice()
+        {
+            var client = new FortnoxWebSocketClient(this.connectionSettings.AccessToken, this.connectionSettings.ClientSecret)
+                .AddTopic(WebSocketTopic.Articles);
+
+            await client.Connect();
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => client.Connect());
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(WebSocketException))]
+        public async Task UserHasToSpecifyTopicsOrThrowsException()
+        {
+            var client = await new FortnoxWebSocketClient(this.connectionSettings.AccessToken, this.connectionSettings.ClientSecret)
+                .Connect();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(WebSocketException))]
+        public async Task InvalidCredentialsThrowsException()
+        {
+            var client = await new FortnoxWebSocketClient("NotAnAccessToken", "NotASecret")
+                .Connect();
+        }
+
+        [TestMethod]
+        public async Task CanSubscribeToMultipleTopics()
+        {
+            var listeningTask = new Task(async () =>
+            {
+                var client = new FortnoxWebSocketClient(this.connectionSettings.AccessToken, this.connectionSettings.ClientSecret)
+                    .AddTopic(WebSocketTopic.Articles)
+                    .AddTopic(WebSocketTopic.Orders);
+
+                await client.ConnectAndListen(async (socket) =>
+                {
+                    var recievedArticleUpdate = false;
+                    var recievedOrderUpdate = false;
+
+                    foreach (var response in client.GetNextEvent(socket))
+                    {
+                        if (response != null)
+                        {
+                            Assert.IsTrue(response.Topic == "articles" || response.Topic == "orders");
+                            
+                            if (response.Topic == "articles")
+                            {
+                                recievedArticleUpdate = true;
+                            }
+                            else if (response.Topic == "orders")
+                            {
+                                recievedOrderUpdate = true;
+                            }
+
+                            Assert.IsTrue(response.Type == "article-updated-v1" || response.Type == "order-updated-v1");
+                            Assert.IsTrue(response.EntityId == "100370" || response.EntityId == "1");
+
+                            if (recievedArticleUpdate && recievedOrderUpdate)
+                            {
+                                return;
+                            }
+                        }
+                    }
+                });
+            }, TaskCreationOptions.LongRunning);
+            listeningTask.Start();
+
+            var comment = $"Comment: {DateTime.Now}";
+            var request = new OrderListRequest(this.connectionSettings.AccessToken, this.connectionSettings.ClientSecret);
+            var order = new Order { DocumentNumber = 1, Comments = comment };
+            var updatedOrder = OrderService.UpdateOrderAsync(request, order).GetAwaiter().GetResult();
+            Assert.AreEqual(comment, updatedOrder.Comments);
+            
+            var updatedDescription = $"TestArtikel {DateTime.UtcNow}";
+            var article = new Article { Description = updatedDescription, ArticleNumber = "100370" };
+            var articleRequest = new FortnoxApiRequest(this.connectionSettings.AccessToken, this.connectionSettings.ClientSecret);
+            var updatedArticle = ArticleService.UpdateArticleAsync(articleRequest, article).GetAwaiter().GetResult();
+            Assert.AreEqual(updatedDescription, updatedArticle.Description);
+
+            await listeningTask;
+        }
+    }
+}

--- a/Fortnox.NET/Constants/ApiEndpoints.cs
+++ b/Fortnox.NET/Constants/ApiEndpoints.cs
@@ -5,7 +5,10 @@ namespace FortnoxNET.Constants
         private const string _apiVersion = "3";
         private static readonly string _baseUri = $"https://api.fortnox.se/{_apiVersion}";
 
-		public static readonly string AbsenceTransactions = $"{_baseUri}/absencetransactions";
+        private const string _webSocketApiVersion = "v1";
+        public static readonly string WebSocketURI = $"wss://ws.fortnox.se/topics-{_webSocketApiVersion}";
+
+        public static readonly string AbsenceTransactions = $"{_baseUri}/absencetransactions";
 		public static readonly string CustomerInvoices = $"{_baseUri}/invoices";
         public static readonly string Vouchers = $"{_baseUri}/vouchers";
         public static readonly string VoucherSublist = $"{_baseUri}/vouchers/sublist";

--- a/Fortnox.NET/WebSockets/FortnoxWebSocketClient.cs
+++ b/Fortnox.NET/WebSockets/FortnoxWebSocketClient.cs
@@ -107,15 +107,8 @@ namespace FortnoxNET.WebSockets
                 }
             }
 
-            try
-            {
-                var deserializedResult = JsonConvert.DeserializeObject<T>(resultString, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
-                return deserializedResult;
-            }
-            catch (Exception e)
-            {
-                throw e;
-            }
+            var deserializedResult = JsonConvert.DeserializeObject<T>(resultString, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
+            return deserializedResult;
         }
 
         /// <summary>
@@ -180,13 +173,13 @@ namespace FortnoxNET.WebSockets
         /// <returns>The current instance of <see cref="FortnoxWebSocketClient"/></returns>
         public FortnoxWebSocketClient AddTopic(WebSocketTopic topic)
         {
-            Type type = topic.GetType();
-            FieldInfo fi = type.GetField(topic.ToString());
+            var type = topic.GetType();
+            var fieldInfo = type.GetField(topic.ToString());
             
-            WebSocketTopicStringValueAttribute attr = 
-                fi.GetCustomAttribute(typeof(WebSocketTopicStringValueAttribute), false) as WebSocketTopicStringValueAttribute;
+            var attribute =
+                fieldInfo.GetCustomAttribute(typeof(WebSocketTopicStringValueAttribute), false) as WebSocketTopicStringValueAttribute;
 
-            this._topics.Add(attr.Value);
+            this._topics.Add(attribute.Value);
 
             return this;
         }
@@ -219,6 +212,7 @@ namespace FortnoxNET.WebSockets
         ///         {
         ///             (await client.Connect()).Listen(async (socket) =>
         ///             {
+        ///                 // GetNextEvent returns an enumeration and is iterated asyncrounusly as new events are yielded
         ///                 foreach (var response in client.GetNextEvent(socket))
         ///                 {
         ///                     if (response != null)

--- a/Fortnox.NET/WebSockets/FortnoxWebSocketClient.cs
+++ b/Fortnox.NET/WebSockets/FortnoxWebSocketClient.cs
@@ -1,0 +1,273 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.WebSockets;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FortnoxNET.Constants;
+using FortnoxNET.WebSockets.Models;
+using Newtonsoft.Json;
+
+namespace FortnoxNET.WebSockets
+{
+    public class FortnoxWebSocketClient
+    {
+        private const int DEFAULT_BUFFER_SIZE = 2048;
+
+        private ClientWebSocket _webSocket;
+
+        private Uri _fortnoxWebSocketURI;
+        
+        private List<string> _accessTokens { get; set; }
+
+        private string _clientSecret { get; set; }
+
+        private List<string> _topics { get; set; }
+
+        private int _bufferSize { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FortnoxWebSocketClient"/> class with the specified AccessToken, ClientSecret and optional BufferSize.
+        /// </summary>
+        /// <param name="accessToken">The Fortnox passkey.</param>
+        /// <param name="clientSecret">The integrators key for making requests to Fortnox.</param>
+        /// <param name="bufferSize">Optional target buffer size when recieving messages from the socket connection.</param>
+        public FortnoxWebSocketClient(string accessToken, string clientSecret, int bufferSize = DEFAULT_BUFFER_SIZE)
+        {
+            this._accessTokens = new List<string>();
+            this._accessTokens.Add(accessToken);
+
+            this._clientSecret = clientSecret;
+            this._fortnoxWebSocketURI = new Uri(ApiEndpoints.WebSocketURI);
+
+            this._webSocket = new ClientWebSocket();
+
+            this._topics = new List<string>();
+
+            this._bufferSize = bufferSize;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FortnoxWebSocketClient"/> class with the specified AccessTokens, ClientSecret and optional BufferSize.
+        /// </summary>
+        /// <param name="accessTokens">List of Fortnox passkeys.</param>
+        /// <param name="clientSecret">The integrators key for making requests to Fortnox.</param>
+        /// <param name="bufferSize">Optional target buffer size when recieving messages from the socket connection.</param>
+        public FortnoxWebSocketClient(List<string> accessTokens, string clientSecret, int bufferSize = DEFAULT_BUFFER_SIZE)
+        {
+            this._accessTokens = new List<string>(accessTokens);
+
+            this._clientSecret = clientSecret;
+            this._fortnoxWebSocketURI = new Uri(ApiEndpoints.WebSocketURI);
+
+            this._webSocket = new ClientWebSocket();
+
+            this._topics = new List<string>();
+
+            this._bufferSize = bufferSize;
+        }
+
+        /// <summary>
+        /// Sends the specified data on the underlying <see cref="System.Net.WebSockets.ClientWebSocket"/> and then recieves the next message as an asynchronous operation.
+        /// Then deserializes the recieved data as the specified .NET type.
+        /// </summary>
+        /// <typeparam name="T">The .NET type to deserialize the recieved message to.</typeparam>
+        /// <param name="message">The data to send.</param>
+        /// <returns>The deserialized message.</returns>
+        private async Task<T> SendAndRecieveOnce<T>(string message)
+        {
+            var messageBuffer = new ArraySegment<byte>(Encoding.ASCII.GetBytes(message));
+            await _webSocket.SendAsync(messageBuffer, WebSocketMessageType.Text, true, CancellationToken.None);
+            
+            var finished = false;
+            var resultString = "";
+
+            while (!finished)
+            {
+                if (_webSocket.State == WebSocketState.Open)
+                {
+                    var resultBuffer = new byte[this._bufferSize];
+                    var result = await _webSocket.ReceiveAsync(new ArraySegment<byte>(resultBuffer), CancellationToken.None);
+
+                    if (result.MessageType == WebSocketMessageType.Close)
+                    {
+                        await _webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
+                        throw new WebSocketException($"Websocket connection closed unexpectedly. Reason: {result.CloseStatus}");
+                    }
+                    else
+                    {
+                        resultString += Encoding.ASCII.GetString(resultBuffer);
+                        finished = result.EndOfMessage;
+                    }
+                }
+                else
+                {
+                    throw new WebSocketException("Unable to recieve as Websocket is closed.");
+                }
+            }
+
+            try
+            {
+                var deserializedResult = JsonConvert.DeserializeObject<T>(resultString, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
+                return deserializedResult;
+            }
+            catch (Exception e)
+            {
+                throw e;
+            }
+        }
+
+        /// <summary>
+        /// Helper function that allows the caller to specify a callback function that accepts the underlying <see cref="System.Net.WebSockets.ClientWebSocket"/>.
+        /// </summary>
+        /// <param name="callback">An asynchronous callback function that accepts a <see cref="System.Net.WebSockets.ClientWebSocket"/> in its parameters.</param>
+        /// <returns>An empty <see cref="Task"/></returns>
+        public async Task Listen(Func<ClientWebSocket, Task> callback)
+        {
+            await callback.Invoke(this._webSocket);
+        }
+
+        /// <summary>
+        /// Initiates the connection to the underlying <see cref="System.Net.WebSockets.ClientWebSocket"/> as well as subscribes to all the specified topics as an asynchronous operation.
+        /// </summary>
+        /// <returns>The current instance of <see cref="FortnoxWebSocketClient"/> as an asynchronous operation.</returns>
+        public async Task<FortnoxWebSocketClient> Connect()
+        {
+            // TODO(Oskar): Should we keep anonymous objects or create something concrete?
+            await _webSocket.ConnectAsync(_fortnoxWebSocketURI, CancellationToken.None);
+
+            var AddTenantsObject = new { command = WebSocketCommands.AddTenants, clientSecret = _clientSecret, accessTokens = new List<string>(_accessTokens) };
+            var AddTenantsResult = await SendAndRecieveOnce<WebSocketCommandResponse>(JsonConvert.SerializeObject(AddTenantsObject));
+
+            if (AddTenantsResult.Result.Equals("error"))
+            {
+                throw new WebSocketException("Unable to add tenants.");
+            }
+
+            if (_topics.Count <= 0)
+            {
+                throw new WebSocketException("No topics specified.");
+            }
+
+            var AddTopicObject = new { command = WebSocketCommands.AddTopics, topics = new List<object>() };
+            foreach(var topic in _topics)
+            {
+                AddTopicObject.topics.Add(new { topic = topic });
+            }
+
+            var AddTopicResult = await SendAndRecieveOnce<WebSocketCommandResponse>(JsonConvert.SerializeObject(AddTopicObject));
+            if (AddTopicResult.Result.Equals("error"))
+            {
+                throw new WebSocketException($"Error adding topic: {string.Join(",", AddTopicResult.InvalidTopics)}");
+            }
+
+            var SubscribeObject = new { command = WebSocketCommands.Subscribe };
+            var SubscribeResult = await SendAndRecieveOnce<WebSocketCommandResponse>(JsonConvert.SerializeObject(SubscribeObject));
+
+            if (!SubscribeResult.Result.Equals("ok"))
+            {
+                throw new WebSocketException("Failed to subscribe.");
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds the specified <see cref="WebSocketTopic"/> to the list of topics to subscribe to when calling <see cref="Connect"/>.
+        /// </summary>
+        /// <param name="topic">The target topic.</param>
+        /// <returns>The current instance of <see cref="FortnoxWebSocketClient"/></returns>
+        public FortnoxWebSocketClient AddTopic(WebSocketTopic topic)
+        {
+            Type type = topic.GetType();
+            FieldInfo fi = type.GetField(topic.ToString());
+            
+            WebSocketTopicStringValueAttribute attr = 
+                fi.GetCustomAttribute(typeof(WebSocketTopicStringValueAttribute), false) as WebSocketTopicStringValueAttribute;
+
+            this._topics.Add(attr.Value);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Combines both <see cref="Connect"/> and <see cref="Listen(Func{ClientWebSocket, Task})"/> into a single function.
+        /// </summary>
+        /// <param name="callback">An asynchronous callback function that accepts a <see cref="System.Net.WebSockets.ClientWebSocket"/> in its parameters.</param>
+        /// <returns>An empty <see cref="Task"/></returns>
+        public async Task ConnectAndListen(Func<ClientWebSocket, Task> callback)
+        {
+            await Connect();
+            await callback.Invoke(this._webSocket);
+        }
+
+        /// <summary>
+        /// A helper method that manages recieving buffered data from the underlying <see cref="System.Net.WebSockets.ClientWebSocket"/> and allows the caller
+        /// handle the incoming data through the <see cref="IEnumerable{T}"/> interface.
+        /// </summary>
+        /// <param name="socket"></param>
+        /// <returns>A <see cref="WebSocketEvent"/> when successfully read event; null otherwise.</returns>
+        /// <example>
+        /// <code>
+        ///     var client = new FortnoxWebSocketClient("AccessToken", "ClientSecret")
+        ///     .AddTopic(WebSocketTopic.Articles);
+        ///     
+        ///     var task = new Task(async () =>
+        ///     {
+        ///         try
+        ///         {
+        ///             (await client.Connect()).Listen(async (socket) =>
+        ///             {
+        ///                 foreach (var response in client.GetNextEvent(socket))
+        ///                 {
+        ///                     if (response != null)
+        ///                     {
+        ///                         // Process messages here.
+        ///                         return;
+        ///                     }
+        ///                 }
+        ///             }).GetAwaiter().GetResult();
+        ///         }
+        ///         catch (Exception e)
+        ///         {
+        ///             // Handle errors.
+        ///             throw e;
+        ///         }
+        ///     }, TaskCreationOptions.LongRunning);
+        ///     task.Start();
+        /// </code>
+        /// </example>
+        public IEnumerable<WebSocketEvent> GetNextEvent(ClientWebSocket socket)
+        {
+            var finished = false;
+            var resultString = "";
+            while (!finished)
+            {
+                if (socket.State == WebSocketState.Open)
+                {
+                    var buffer = new byte[DEFAULT_BUFFER_SIZE];
+                    var result = socket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None).GetAwaiter().GetResult();
+                    if (result.MessageType == WebSocketMessageType.Close)
+                    {
+                        socket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None).GetAwaiter().GetResult();
+                        yield return null;
+                    }
+                    else
+                    {
+                        resultString += Encoding.ASCII.GetString(buffer);
+                        finished = result.EndOfMessage;
+                    }
+                }
+                else
+                {
+                    yield return null;
+                }
+            }
+
+            var response = JsonConvert.DeserializeObject<WebSocketEvent>(resultString);
+            yield return response;
+
+        }
+    }
+}

--- a/Fortnox.NET/WebSockets/Models/WebSocketCommandResponse.cs
+++ b/Fortnox.NET/WebSockets/Models/WebSocketCommandResponse.cs
@@ -1,0 +1,23 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace FortnoxNET.WebSockets.Models
+{
+    public class WebSocketCommandResponse
+    {
+        [JsonProperty(PropertyName = "response")]
+        public string Response { get; set; }
+
+        [JsonProperty(PropertyName = "result")]
+        public string Result { get; set; }
+
+        [JsonProperty(PropertyName = "tenantIds")]
+        public dynamic TenantIDs { get; set; } // TODO(Oskar): Don't use dynamic.
+
+        [JsonProperty(PropertyName = "invalidTokens")]
+        public List<string> InvalidTokens { get; set; }
+
+        [JsonProperty(PropertyName = "invalidTopics")]
+        public List<string> InvalidTopics { get; set; }
+    }
+}

--- a/Fortnox.NET/WebSockets/Models/WebSocketEvent.cs
+++ b/Fortnox.NET/WebSockets/Models/WebSocketEvent.cs
@@ -1,9 +1,5 @@
 ﻿using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FortnoxNET.WebSockets.Models
 {

--- a/Fortnox.NET/WebSockets/Models/WebSocketEvent.cs
+++ b/Fortnox.NET/WebSockets/Models/WebSocketEvent.cs
@@ -1,0 +1,31 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FortnoxNET.WebSockets.Models
+{
+    public class WebSocketEvent
+    {
+        [JsonProperty(PropertyName = "offset")]
+        public string Offset { get; set; }
+
+        [JsonProperty(PropertyName = "tenantId")]
+        public long? TenantId { get; set; }
+
+        [JsonProperty(PropertyName = "topic")]
+        public string Topic { get; set; }
+
+        [JsonProperty(PropertyName = "entityId")]
+        public string EntityId { get; set; }
+
+        // TODO(Oskar): Make this some sort of enum type users can do something with.
+        [JsonProperty(PropertyName = "type")]
+        public string Type { get; set; }
+
+        [JsonProperty(PropertyName = "timestamp")]
+        public DateTime Timestamp { get; set; }
+    }
+}

--- a/Fortnox.NET/WebSockets/Models/WebSocketTopic.cs
+++ b/Fortnox.NET/WebSockets/Models/WebSocketTopic.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FortnoxNET.WebSockets.Models
+{
+    public class WebSocketTopicStringValueAttribute : System.Attribute
+    {
+        private string _value;
+
+        public WebSocketTopicStringValueAttribute(string value)
+        {
+            _value = value;
+        }
+
+        public string Value
+        {
+            get { return _value; }
+        }
+    }
+
+    public enum WebSocketTopic
+    {
+        [WebSocketTopicStringValue("invoices")]
+        Invoices,
+        [WebSocketTopicStringValue("customers")]
+        Customers,
+        [WebSocketTopicStringValue("orders")]
+        Orders,
+        [WebSocketTopicStringValue("offers")]
+        Offers,
+        [WebSocketTopicStringValue("articles")]
+        Articles,
+        [WebSocketTopicStringValue("currencies")]
+        Currencies,
+        [WebSocketTopicStringValue("termsofdeliveries")]
+        TermsOfDeliveries,
+        [WebSocketTopicStringValue("waysofdeliveries")]
+        WaysOfDeliveries,
+        [WebSocketTopicStringValue("termsofpayments")]
+        TermsOfPayments,
+    }
+}

--- a/Fortnox.NET/WebSockets/WebSocketCommands.cs
+++ b/Fortnox.NET/WebSockets/WebSocketCommands.cs
@@ -1,0 +1,10 @@
+﻿namespace FortnoxNET.WebSockets
+{
+    public static class WebSocketCommands
+    {
+        public static readonly string AddTenants = "add-tenants-v1";
+        public static readonly string RemoveTenants = "remove-tenants-v1";
+        public static readonly string AddTopics = "add-topics-v1";
+        public static readonly string Subscribe = "subscribe-v1";
+    }
+}

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ var task = new Task(async () =>
     {
         (await client.Connect()).Listen(async (socket) =>
         {
+            // GetNextEvent returns an enumeration and is iterated asyncrounusly as new events are yielded
             foreach (var response in client.GetNextEvent(socket))
             {
                 if (response != null)

--- a/README.md
+++ b/README.md
@@ -1,21 +1,24 @@
 # Fortnox.NET
+
 .NET bindings for the <a href="https://developer.fortnox.se/documentation/">Fortnox</a> API.
- 
+
 ## Usage
+
 To access the Fortnox API you need an Access Token and Client Secret: <a href="https://developer.fortnox.se/general/authentication/">https://developer.fortnox.se/general/authentication/</a>.
- 
+
 The unit tests in this repository serves as a way for us to make sure our code works as well as examples of how to call the different routes that the Fortnox API provides. There are mainly two ways to make a request using this SDK, one for requesting a list of resources and one for requesting a single resource.
- 
+
 ### Listed resource
+
 When requesting a list of resources you create a ListRequest object of the type of resource you are interested in.
- 
+
 ```CSharp
 var request = new OrderListRequest("ACCESS-TOKEN", "CLIENT-SECRET");
 var orders = await OrderService.GetOrdersAsync(request);
 ```
- 
+
 You can also add filters and ordering to routes that accepts it, for example:
- 
+
 ```CSharp
 var request = new EmployeeListRequest("ACCESS-TOKEN", "CLIENT-SECRET")
 {
@@ -23,18 +26,60 @@ var request = new EmployeeListRequest("ACCESS-TOKEN", "CLIENT-SECRET")
 };
 var employeeList = await EmployeeService.GetEmployeesAsync(request);
 ```
- 
+
 ### Single resource
+
 When requesting a single resource you create a FortnoxApiRequest object and pass that into the service to make your request.
- 
+
 ```CSharp
 var request = new FortnoxApiRequest("ACCESS-TOKEN", "CLIENT-SECRET");
 var response = await ArticleService.GetArticleAsync(request, "100370");
 ```
- 
+
+### WebSocket
+
+If you want to subscribe to changes instead of having to poll for new information you can use the Fortnox WebSocket API. 
+You start by creating a FortnoxWebSocketClient with your AccessToken and ClientSecret. You can then add the desired topics to your connection and once you're ready call `Connect` to initiate the connection.
+
+```CSharp
+var client = await new FortnoxWebSocketClient(this.connectionSettings.AccessToken, this.connectionSettings.ClientSecret)
+    .AddTopic(WebSocketTopic.Articles);
+```
+
+Once you're connected you can call `Listen` and specify your callback function, in order for this to not block your current thread you can run this within a Task like in the following snippet. Inside your listener callback you can make use of the `GetNextEvent` helper method to process messages as they come.
+
+```CSharp
+var task = new Task(async () =>
+{
+    try
+    {
+        (await client.Connect()).Listen(async (socket) =>
+        {
+            foreach (var response in client.GetNextEvent(socket))
+            {
+                if (response != null)
+                {
+                    // Process messages here.
+                    return;
+                }
+            }
+        }).GetAwaiter().GetResult();
+    }
+    catch (Exception e)
+    {
+        // Handle errors.
+        throw e;
+    }
+}, TaskCreationOptions.LongRunning);
+task.Start();
+```
+
+More examples of how to use the Fortnox WebSocket API exists within the unit tests for the `FortnoxWebSocketClient` class.
+
 ## Features
+
 Bellow is a list of the supported API endpoints within the SDK.
- 
+
 * Absence Transactions
 * Account Charts
 * Accounts
@@ -79,12 +124,31 @@ Bellow is a list of the supported API endpoints within the SDK.
 * Voucher Series
 * Vouchers
 * Way of Deliveries
- 
+
+### WebSockets
+
+This library also supports the Fortnox WebSocket API which allows the user to get notifications about changes instead of having to poll using the above API endpoints.
+
+The supported topics to subscribe to for changes are the following:
+
+* Invoices
+* Customers
+* Orders
+* Offers
+* Articles
+* Currencies
+* TermsOfDeliveries
+* WaysOfDeliveries
+* TermsOfPayments
+
 ## Contributing
-Thank you for considering contributing to Fortnox.NET. This part of the document provides information on how to get the project to run and build the project. 
+
+Thank you for considering contributing to Fortnox.NET. This part of the document provides information on how to get the project to run and build the project.
 
 ### Developing
+
 The project is using a service oriented structure where you, for example, have `ArticleService.cs` that defines operations that you can perform for the Articles endpoint. For resources that can be filtered, sorted or ordered an additional helper object `ArticleListRequest.cs` is also created.
- 
+
 ### Testing
+
 Currently the tests are only made to be working for our dataset, hence most of the tests will fail. If you are contributing to this project you are encouraged to make a test that would work for any dataset and not only ours.


### PR DESCRIPTION
### Description
A new implementation towards the Fortnox WebSocket API allowing the user to subscribe to different topics and then recieve events when something happened with the subscribed topics.

The available topics are: 
* Invoices
* Customers
* Orders
* Offers
* Articles
* Currencies
* TermsOfDeliveries
* WaysOfDeliveries
* TermsOfPayments

### Checklist
- [X] Code compiles correctly
- [X] Created tests which fail without the change (if possible)
- [X] Extended the README / documentation, if necessary