### PR TITLE
Fixed method name spelling error.

### DIFF
--- a/Fortnox.NET.Tests/Fortnox.NET.Tests/WebSocket/FortnoxWebSocketClientTest.cs
+++ b/Fortnox.NET.Tests/Fortnox.NET.Tests/WebSocket/FortnoxWebSocketClientTest.cs
@@ -98,8 +98,8 @@ namespace FortnoxNET.Tests.WebSocket
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
             cancellationTokenSource.CancelAfter(2500);
             CancellationToken token = cancellationTokenSource.Token;
-            
-            // Recieve that will be cancelled after 2,5 seconds.
+
+            // Receive that will be cancelled after 2,5 seconds.
             await Assert.ThrowsExceptionAsync<TaskCanceledException>(() => client.Receive(token));
 
             // Underlying ClientWebSocket state will be set to "Aborted" once cancelled so we cannot re-use the socket now.
@@ -120,10 +120,10 @@ namespace FortnoxNET.Tests.WebSocket
                 await client.AddTopic(WebSocketTopic.Orders);
                 await client.Subscribe();
 
-                var recievedArticleUpdate = false;
-                var recievedOrderUpdate = false;
+                var receivedArticleUpdate = false;
+                var receivedOrderUpdate = false;
 
-                while (!recievedArticleUpdate && !recievedOrderUpdate)
+                while (!receivedArticleUpdate && !receivedOrderUpdate)
                 {
                     var response = await client.Receive();
                     if (response.Type == WebSocketResponseType.EventResponse)
@@ -132,17 +132,17 @@ namespace FortnoxNET.Tests.WebSocket
 
                         if (response.Topic == WebSocketTopic.Articles.ToString())
                         {
-                            recievedArticleUpdate = true;
+                            receivedArticleUpdate = true;
                         }
                         else if (response.Topic == WebSocketTopic.Orders.ToString())
                         {
-                            recievedOrderUpdate = true;
+                            receivedOrderUpdate = true;
                         }
 
                         Assert.IsTrue(response.EventType == WebSocketEventType.ArticleUpdated || response.EventType == WebSocketEventType.OrderUpdated);
                         Assert.IsTrue(response.EntityId == "100370" || response.EntityId == "1");
 
-                        if (recievedArticleUpdate && recievedOrderUpdate)
+                        if (receivedArticleUpdate && receivedOrderUpdate)
                         {
                             return;
                         }

--- a/Fortnox.NET.Tests/Fortnox.NET.Tests/WebSocket/FortnoxWebSocketClientTest.cs
+++ b/Fortnox.NET.Tests/Fortnox.NET.Tests/WebSocket/FortnoxWebSocketClientTest.cs
@@ -25,20 +25,20 @@ namespace FortnoxNET.Tests.WebSocket
             await client.Connect();
             
             await client.AddTenant(this.connectionSettings.AccessToken);
-            var addTenantResponse = await client.Recieve();
+            var addTenantResponse = await client.Receive();
             Assert.IsTrue(addTenantResponse.Type == WebSocketResponseType.CommandResponse);
             Assert.IsTrue(addTenantResponse.Result.Equals("ok"));
             Assert.IsTrue(addTenantResponse.Response == WebSocketCommands.AddTenants);
 
 
             await client.AddTopic(WebSocketTopic.Articles);
-            var addTopicResponse = await client.Recieve();
+            var addTopicResponse = await client.Receive();
             Assert.IsTrue(addTopicResponse.Type == WebSocketResponseType.CommandResponse);
             Assert.IsTrue(addTopicResponse.Result.Equals("ok"));
             Assert.IsTrue(addTopicResponse.Response == WebSocketCommands.AddTopics);
             
             await client.Subscribe();
-            var subscribeResponse = await client.Recieve();
+            var subscribeResponse = await client.Receive();
             Assert.IsTrue(subscribeResponse.Type == WebSocketResponseType.CommandResponse);
             Assert.IsTrue(subscribeResponse.Result.Equals("ok"));
             Assert.IsTrue(subscribeResponse.Response == WebSocketCommands.Subscribe);
@@ -61,10 +61,10 @@ namespace FortnoxNET.Tests.WebSocket
             var updatedArticle = ArticleService.UpdateArticleAsync(request, article).GetAwaiter().GetResult();
             Assert.AreEqual(updatedDescription, updatedArticle.Description);
 
-            var response = await client.Recieve();
+            var response = await client.Receive();
             while (response.Type != WebSocketResponseType.EventResponse)
             {
-                response = await client.Recieve();
+                response = await client.Receive();
             }
 
             Assert.IsTrue(response.Topic == WebSocketTopic.Articles.ToString());
@@ -89,21 +89,21 @@ namespace FortnoxNET.Tests.WebSocket
             var client = new FortnoxWebSocketClient(this.connectionSettings.ClientSecret);
             await client.Connect();
             await client.AddTenant(this.connectionSettings.AccessToken);
-            await client.Recieve();
+            await client.Receive();
             await client.AddTopic(WebSocketTopic.Articles);
-            await client.Recieve();
+            await client.Receive();
             await client.Subscribe();
-            await client.Recieve();
+            await client.Receive();
 
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
             cancellationTokenSource.CancelAfter(2500);
             CancellationToken token = cancellationTokenSource.Token;
             
             // Recieve that will be cancelled after 2,5 seconds.
-            await Assert.ThrowsExceptionAsync<TaskCanceledException>(() => client.Recieve(token));
+            await Assert.ThrowsExceptionAsync<TaskCanceledException>(() => client.Receive(token));
 
             // Underlying ClientWebSocket state will be set to "Aborted" once cancelled so we cannot re-use the socket now.
-            await Assert.ThrowsExceptionAsync<WebSocketException>(() => client.Recieve(token));
+            await Assert.ThrowsExceptionAsync<WebSocketException>(() => client.Receive(token));
 
             await client.Close();
         }
@@ -125,7 +125,7 @@ namespace FortnoxNET.Tests.WebSocket
 
                 while (!recievedArticleUpdate && !recievedOrderUpdate)
                 {
-                    var response = await client.Recieve();
+                    var response = await client.Receive();
                     if (response.Type == WebSocketResponseType.EventResponse)
                     {
                         Assert.IsTrue(response.Topic == WebSocketTopic.Articles.ToString() || response.Topic == WebSocketTopic.Orders.ToString());

--- a/Fortnox.NET/WebSockets/FortnoxWebSocketClient.cs
+++ b/Fortnox.NET/WebSockets/FortnoxWebSocketClient.cs
@@ -35,7 +35,7 @@ namespace FortnoxNET.WebSockets
         /// </summary>
         /// <param name="accessToken">The Fortnox passkey.</param>
         /// <param name="clientSecret">The integrators key for making requests to Fortnox.</param>
-        /// <param name="bufferSize">Optional target buffer size when recieving messages from the socket connection.</param>
+        /// <param name="bufferSize">Optional target buffer size when receiving messages from the socket connection.</param>
         public FortnoxWebSocketClient(string clientSecret, int bufferSize = DEFAULT_BUFFER_SIZE)
         {
             this._accessTokens = new List<string>();

--- a/Fortnox.NET/WebSockets/FortnoxWebSocketClient.cs
+++ b/Fortnox.NET/WebSockets/FortnoxWebSocketClient.cs
@@ -80,7 +80,7 @@ namespace FortnoxNET.WebSockets
             await _webSocket.SendAsync(messageBuffer, WebSocketMessageType.Text, true, cancellationToken);
         }
 
-        public async Task<WebSocketResponse> Recieve(CancellationToken cancellationToken = default)
+        public async Task<WebSocketResponse> Receive(CancellationToken cancellationToken = default)
         {
             var finished = false;
             var resultString = "";

--- a/Fortnox.NET/WebSockets/FortnoxWebSocketClient.cs
+++ b/Fortnox.NET/WebSockets/FortnoxWebSocketClient.cs
@@ -105,7 +105,7 @@ namespace FortnoxNET.WebSockets
                 }
                 else
                 {
-                    throw new WebSocketException("Unable to recieve as Websocket is closed.");
+                    throw new WebSocketException("Unable to receive as Websocket is closed.");
                 }
             }
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ var response = await ArticleService.GetArticleAsync(request, "100370");
 ### WebSocket
 
 If you want to subscribe to changes instead of having to poll for new information you can use the Fortnox WebSocket API.
-You start by creating a FortnoxWebSocketClient with your ClientSecret. Proceed with calling `Connect` to initiate the connection with Fortnox followed by adding the desired topics and tenants to your connection and once you're ready call `Subscribe` to start recieving events.
+You start by creating a FortnoxWebSocketClient with your ClientSecret. Proceed with calling `Connect` to initiate the connection with Fortnox followed by adding the desired topics and tenants to your connection and once you're ready call `Subscribe` to start receiving events.
 
 ```CSharp
 var client = new FortnoxWebSocketClient(this.connectionSettings.ClientSecret);
@@ -55,24 +55,24 @@ await client.AddTopic(WebSocketTopic.Articles);
 await client.Subscribe();
 ```
 
-Once you're subscribed you can call `Recieve` to recieve incoming messages. Performing actions such as `AddTenant`, `AddTopic` and `Subscribe` also results in a message being returned, if you wish you can handle those as well. In the following snippet we see an example which stores all action responses in their own variables followed by a while loop listening for incoming events.
+Once you're subscribed you can call `Receive` to receive incoming messages. Performing actions such as `AddTenant`, `AddTopic` and `Subscribe` also results in a message being returned, if you wish you can handle those as well. In the following snippet we see an example which stores all action responses in their own variables followed by a while loop listening for incoming events.
 
 ```CSharp
 var client = new FortnoxWebSocketClient(this.connectionSettings.ClientSecret);
 await client.Connect();
 
 await client.AddTenant(this.connectionSettings.AccessToken);
-var addTenantResponse = await client.Recieve();
+var addTenantResponse = await client.Receive();
 
 await client.AddTopic(WebSocketTopic.Articles);
-var addTopicResponse = await client.Recieve();
+var addTopicResponse = await client.Receive();
 
 await client.Subscribe();
-var subscribeResponse = await client.Recieve();
+var subscribeResponse = await client.Receive();
 
 while (ListenToIncomingEvents)
 {
-    var response = await client.Recieve();
+    var response = await client.Receive();
     if (response.Type == WebSocketResponseType.EventResponse)
     {
         // Handle events


### PR DESCRIPTION
### Description
Fixed spelling error in member function.

### Checklist
- [X] Code compiles correctly
- [X] Created tests which fail without the change (if possible)
- [X] Extended the README / documentation, if necessary