### PR TITLE
Added support for actions on Invoices.

### DIFF
--- a/Fortnox.NET.Tests/Fortnox.NET.Tests/InvoiceTests.cs
+++ b/Fortnox.NET.Tests/Fortnox.NET.Tests/InvoiceTests.cs
@@ -8,9 +8,7 @@ using FortnoxNET.Services;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace FortnoxNET.Tests

--- a/Fortnox.NET/Models/Invoice/Invoice.cs
+++ b/Fortnox.NET/Models/Invoice/Invoice.cs
@@ -63,9 +63,9 @@ namespace FortnoxNET.Models.Invoice
         
         public string Currency { get; set; }
         
-        public int CurrencyRate { get; set; }
+        public int? CurrencyRate { get; set; }
         
-        public int CurrencyUnit { get; set; }
+        public int? CurrencyUnit { get; set; }
         
         public string CustomerName { get; set; }
         
@@ -139,6 +139,7 @@ namespace FortnoxNET.Models.Invoice
         
         public bool NotCompleted { get; set; }
         
+        [JsonReadOnly]
         public bool NoxFinans { get; set; }
         
         public string OCR { get; set; }

--- a/Fortnox.NET/Services/InvoiceService.cs
+++ b/Fortnox.NET/Services/InvoiceService.cs
@@ -3,6 +3,7 @@ using FortnoxNET.Communication.Invoice;
 using FortnoxNET.Constants;
 using FortnoxNET.Models.Invoice;
 using System.Net.Http;
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 
 namespace FortnoxNET.Services
@@ -44,7 +45,7 @@ namespace FortnoxNET.Services
             var apiRequest =
                 new FortnoxApiClientRequest<SingleResource<Invoice>>(HttpMethod.Post, request.AccessToken, request.ClientSecret, $"{ApiEndpoints.Invoices}")
                 {
-                    Data = new SingleResource<Invoice> { Data = invoice}
+                    Data = new SingleResource<Invoice> { Data = invoice }
                 };
 
             return (await FortnoxAPIClient.CallAsync(apiRequest)).Data;
@@ -56,10 +57,84 @@ namespace FortnoxNET.Services
                 new FortnoxApiClientRequest<SingleResource<Invoice>>(HttpMethod.Put, request.AccessToken, request.ClientSecret,
                                                                    $"{ApiEndpoints.Invoices}/{invoice.DocumentNumber}")
                 {
-                    Data = new SingleResource<Invoice> { Data = invoice}
+                    Data = new SingleResource<Invoice> { Data = invoice }
                 };
 
             return (await FortnoxAPIClient.CallAsync(apiRequest)).Data;
         }
+
+        public static async Task<Invoice> BookkeepInvoiceAsync(FortnoxApiRequest request, string invoiceNumber)
+        {
+            var apiRequest =
+                new FortnoxApiClientRequest<SingleResource<Invoice>>(HttpMethod.Put, request.AccessToken, request.ClientSecret,
+                    $"{ApiEndpoints.Invoices}/{invoiceNumber}/bookkeep");
+            return (await FortnoxAPIClient.CallAsync(apiRequest)).Data;
+        }
+
+        public static async Task<Invoice> CancelInvoiceAsync(FortnoxApiRequest request, string invoiceNumber)
+        {
+            var apiRequest =
+                new FortnoxApiClientRequest<SingleResource<Invoice>>(HttpMethod.Put, request.AccessToken, request.ClientSecret,
+                    $"{ApiEndpoints.Invoices}/{invoiceNumber}/cancel");
+            return (await FortnoxAPIClient.CallAsync(apiRequest)).Data;
+        }
+
+        public static async Task<Invoice> CreditInvoiceAsync(FortnoxApiRequest request, string invoiceNumber)
+        {
+            var apiRequest =
+                new FortnoxApiClientRequest<SingleResource<Invoice>>(HttpMethod.Put, request.AccessToken, request.ClientSecret,
+                    $"{ApiEndpoints.Invoices}/{invoiceNumber}/credit");
+            return (await FortnoxAPIClient.CallAsync(apiRequest)).Data;
+        }
+
+        public static async Task<Invoice> SendInvoiceEmailAsync(FortnoxApiRequest request, string invoiceNumber)
+        {
+            var apiRequest =
+                new FortnoxApiClientRequest<SingleResource<Invoice>>(HttpMethod.Get, request.AccessToken, request.ClientSecret,
+                    $"{ApiEndpoints.Invoices}/{invoiceNumber}/email");
+            return (await FortnoxAPIClient.CallAsync(apiRequest)).Data;
+        }
+
+        public static async Task<Invoice> SendEInvoiceAsync(FortnoxApiRequest request, string invoiceNumber)
+        {
+            var apiRequest =
+                new FortnoxApiClientRequest<SingleResource<Invoice>>(HttpMethod.Get, request.AccessToken, request.ClientSecret,
+                    $"{ApiEndpoints.Invoices}/{invoiceNumber}/einvoice");
+            return (await FortnoxAPIClient.CallAsync(apiRequest)).Data;
+        }
+
+        public static async Task<byte[]> PrintInvoiceAsync(FortnoxApiRequest request, string invoiceNumber)
+        {
+            var apiRequest =
+                new FortnoxApiClientRequest<byte[]>(HttpMethod.Get, request.AccessToken, request.ClientSecret,
+                    $"{ApiEndpoints.Invoices}/{invoiceNumber}/print");
+            return await FortnoxAPIClient.CallAsync(apiRequest);
+        }
+
+        public static async Task<byte[]> PrintInvoiceReminderAsync(FortnoxApiRequest request, string invoiceNumber)
+        {
+            var apiRequest =
+                new FortnoxApiClientRequest<byte[]>(HttpMethod.Get, request.AccessToken, request.ClientSecret,
+                    $"{ApiEndpoints.Invoices}/{invoiceNumber}/printreminder");
+            return await FortnoxAPIClient.CallAsync(apiRequest);
+        }
+
+        public static async Task<Invoice> ExternalPrintInvoiceAsync(FortnoxApiRequest request, string invoiceNumber)
+        {
+            var apiRequest =
+                new FortnoxApiClientRequest<SingleResource<Invoice>>(HttpMethod.Put, request.AccessToken, request.ClientSecret,
+                    $"{ApiEndpoints.Invoices}/{invoiceNumber}/externalprint");
+            return (await FortnoxAPIClient.CallAsync(apiRequest)).Data;
+        }
+
+        public static async Task<byte[]> PreviewInvoiceAsync(FortnoxApiRequest request, string invoiceNumber)
+        {
+            var apiRequest =
+                new FortnoxApiClientRequest<byte[]>(HttpMethod.Get, request.AccessToken, request.ClientSecret,
+                    $"{ApiEndpoints.Invoices}/{invoiceNumber}/preview");
+            return await FortnoxAPIClient.CallAsync(apiRequest);
+        }
+
+
     }
 }

--- a/Fortnox.NET/Services/InvoiceService.cs
+++ b/Fortnox.NET/Services/InvoiceService.cs
@@ -3,7 +3,6 @@ using FortnoxNET.Communication.Invoice;
 using FortnoxNET.Constants;
 using FortnoxNET.Models.Invoice;
 using System.Net.Http;
-using System.Security.Cryptography;
 using System.Threading.Tasks;
 
 namespace FortnoxNET.Services


### PR DESCRIPTION
### Description
Added support for all actions on invoices, this includes the following:


* `bookkeep:` Bookkeeps an invoic
* `cancel:`  Cancels an invoice (same as “Makulerad” in the GUI)
* `credit:` Creates a credit invoice from the provided invoice. The created credit invoice will be referenced in the property CreditInvoiceReference.
* `email:`  Sends an e-mail to the customer with an attached PDF document of the invoice. You can use the properties in the EmailInformation to customize the e-mail message on each invoice.
* `einvoice:`  Sends an e-invoice to the customer with an attached PDF document of the invoice. Note that this action also sets the property Sent as true.
* `print:` This action returns a PDF document with the current template that is used by the specific document. Note that this action also sets the property Sent as true.
* `printreminder:` This action returns a PDF document with the current reminder template that is used by the specific document. Note that this action also sets the property Sent as true.
* `externalprint:` This action is used to set the field Sent as true from an external system without generating a PDF.
preview: This action returns a PDF document with the current template that is used by the specific document. Unliike the action print, this action doesn’t set the property Sent as true.

### Checklist
- [X] Code compiles correctly
- [X] Created tests which fail without the change (if possible)
- [X] Extended the README / documentation, if necessary