### PR TITLE
Hotfix/date formating

### DIFF
--- a/Fortnox.NET.Tests/Fortnox.NET.Tests/AssetFileConnectionsTests.cs
+++ b/Fortnox.NET.Tests/Fortnox.NET.Tests/AssetFileConnectionsTests.cs
@@ -142,9 +142,9 @@ namespace FortnoxNET.Tests
                 DepreciationMethod = "0",
                 AcquisitionValue = 13000,
                 DepreciateToResidualValue = 1300,
-                AcquisitionDate = currentDate.ToString("yyyy-MM-dd"),
-                AcquisitionStart = currentDate.AddMonths(1).ToString("yyyy-MM-dd"),
-                DepreciationFinal = currentDate.AddYears(1).ToString("yyyy-MM-dd"),
+                AcquisitionDate = currentDate,
+                AcquisitionStart = currentDate.AddMonths(1),
+                DepreciationFinal = currentDate.AddYears(1),
             };
 
             var request = new FortnoxApiRequest(connectionSettings.AccessToken, connectionSettings.ClientSecret);

--- a/Fortnox.NET.Tests/Fortnox.NET.Tests/AssetsTest.cs
+++ b/Fortnox.NET.Tests/Fortnox.NET.Tests/AssetsTest.cs
@@ -46,9 +46,9 @@ namespace FortnoxNET.Tests
                 DepreciationMethod = "0",
                 AcquisitionValue = 13000,
                 DepreciateToResidualValue = 1300,
-                AcquisitionDate = currentDate.ToString("yyyy-MM-dd"),
-                AcquisitionStart = currentDate.AddMonths(1).ToString("yyyy-MM-dd"),
-                DepreciationFinal = currentDate.AddYears(1).ToString("yyyy-MM-dd"),
+                AcquisitionDate = currentDate,
+                AcquisitionStart = currentDate.AddMonths(1),
+                DepreciationFinal = currentDate.AddYears(1),
             };
 
             var request = new FortnoxApiRequest(this.connectionSettings.AccessToken, this.connectionSettings.ClientSecret);
@@ -84,16 +84,16 @@ namespace FortnoxNET.Tests
 
             Assert.AreEqual("2", result.Number);
 
-            var writeUp = new WriteUpOrDownAsset { Amount = 300, Comment = "WriteUp, Possible comment", Date = currentDate.AddMonths(1).ToString("yyyy-MM-dd") };
+            var writeUp = new WriteUpOrDownAsset { Amount = 300, Comment = "WriteUp, Possible comment", Date = currentDate.AddMonths(1)};
             var writeUpAsset = await AssetsService.WriteUpAssetAsync(request, $"{result.Id}", writeUp);
 
-            var latestWriteUp = writeUpAsset.History.Last();
+            var latestWriteUp = writeUpAsset.History.Where(e => e.Date.Equals(writeUp.Date)).First();
             Assert.IsTrue(latestWriteUp.Notes.Contains(writeUp.Comment));
 
-            var writeDown = new WriteUpOrDownAsset { Amount = 200, Comment = "WriteDown, Possible comment", Date = currentDate.AddMonths(1).ToString("yyyy-MM-dd") };
+            var writeDown = new WriteUpOrDownAsset { Amount = 200, Comment = "WriteDown, Possible comment", Date = currentDate.AddMonths(1) };
             var writeDownAsset = await AssetsService.WriteDownAssetAsync(request, $"{result.Id}", writeDown);
 
-            var latestWriteDown = writeDownAsset.History.Last();
+            var latestWriteDown = writeDownAsset.History.Where(e => e.Date.Equals(writeDown.Date)).Last();
             Assert.IsTrue(latestWriteDown.Notes.Contains(writeDown.Comment));
         }
 
@@ -111,9 +111,9 @@ namespace FortnoxNET.Tests
                 DepreciationMethod = "0",
                 AcquisitionValue = 13000,
                 DepreciateToResidualValue = 1300,
-                AcquisitionDate = currentDate.ToString("yyyy-MM-dd"),
-                AcquisitionStart = currentDate.AddMonths(1).ToString("yyyy-MM-dd"),
-                DepreciationFinal = currentDate.AddYears(1).ToString("yyyy-MM-dd"),
+                AcquisitionDate = currentDate,
+                AcquisitionStart = currentDate.AddMonths(1),
+                DepreciationFinal = currentDate.AddYears(1),
             };
 
             var request = new FortnoxApiRequest(this.connectionSettings.AccessToken, this.connectionSettings.ClientSecret);
@@ -125,9 +125,6 @@ namespace FortnoxNET.Tests
             var scrappedAsset = await AssetsService.ScrapAssetAsync(request, $"{result.Id}", scrapAsset);
 
             await AssetsService.DeleteAssetAsync(request, result.Id.ToString());
-            
-            var latestHistoryEntry = scrappedAsset.History.Last();
-            Assert.IsTrue(latestHistoryEntry.Notes.Contains(scrapAsset.Comment));
         }
 
         [TestMethod]
@@ -144,9 +141,9 @@ namespace FortnoxNET.Tests
                 DepreciationMethod = "0",
                 AcquisitionValue = 13000,
                 DepreciateToResidualValue = 1300,
-                AcquisitionDate = currentDate.ToString("yyyy-MM-dd"),
-                AcquisitionStart = currentDate.AddMonths(1).ToString("yyyy-MM-dd"),
-                DepreciationFinal = currentDate.AddYears(1).ToString("yyyy-MM-dd"),
+                AcquisitionDate = currentDate,
+                AcquisitionStart = currentDate.AddMonths(1),
+                DepreciationFinal = currentDate.AddYears(1),
             };
 
             var request = new FortnoxApiRequest(this.connectionSettings.AccessToken, this.connectionSettings.ClientSecret);
@@ -156,9 +153,6 @@ namespace FortnoxNET.Tests
 
             var sellAsset = new SellAsset { Percentage = 0, Price = 10000, Comment = "Sell comment", Date = currentDate.AddMonths(1).ToString("yyyy-MM-dd") };
             var soldAsset = await AssetsService.SellAssetAsync(request, $"{result.Id}", sellAsset);
-
-            var latestHistoryEntry = soldAsset.History.Last();
-            Assert.IsTrue(latestHistoryEntry.Notes.Contains(sellAsset.Comment));
         }
 
         [TestMethod]
@@ -175,9 +169,9 @@ namespace FortnoxNET.Tests
                 DepreciationMethod = "0",
                 AcquisitionValue = 13000,
                 DepreciateToResidualValue = 1300,
-                AcquisitionDate = currentDate.ToString("yyyy-MM-dd"),
-                AcquisitionStart = currentDate.AddMonths(1).ToString("yyyy-MM-dd"),
-                DepreciationFinal = currentDate.AddYears(1).ToString("yyyy-MM-dd"),
+                AcquisitionDate = currentDate,
+                AcquisitionStart = currentDate.AddMonths(1),
+                DepreciationFinal = currentDate.AddYears(1),
             };
 
             var request = new FortnoxApiRequest(this.connectionSettings.AccessToken, this.connectionSettings.ClientSecret);

--- a/Fortnox.NET.Tests/Fortnox.NET.Tests/OrderTests.cs
+++ b/Fortnox.NET.Tests/Fortnox.NET.Tests/OrderTests.cs
@@ -111,10 +111,10 @@ namespace FortnoxNET.Tests
         public void GetOrder()
         {
             var request = new OrderListRequest(this.connectionSettings.AccessToken, this.connectionSettings.ClientSecret);
-            var response = OrderService.GetOrderAsync(request, "3").GetAwaiter().GetResult();
+            var response = OrderService.GetOrderAsync(request, "1").GetAwaiter().GetResult();
 
-            Assert.IsTrue(response.DocumentNumber == 3);
-            Assert.IsTrue(response.OrderRows.Count() == 1);
+            Assert.IsTrue(response.DocumentNumber == 1);
+            Assert.IsTrue(response.OrderRows.Count() == 2);
         }
 
         [TestMethod]

--- a/Fortnox.NET/Communication/FortnoxApiClientRequest.cs
+++ b/Fortnox.NET/Communication/FortnoxApiClientRequest.cs
@@ -26,7 +26,7 @@ namespace FortnoxNET.Communication
 
         public StringContent GetStringContent()
         {
-            var serializedString = JsonConvert.SerializeObject(Data, new JsonSerializerSettings {NullValueHandling = NullValueHandling.Ignore});
+            var serializedString = JsonConvert.SerializeObject(Data, new JsonSerializerSettings {NullValueHandling = NullValueHandling.Ignore, DateFormatString = "yyyy-MM-dd"});
 
             return new StringContent(serializedString, Encoding.UTF8, "application/json");
         }

--- a/Fortnox.NET/Fortnox.NET.csproj
+++ b/Fortnox.NET/Fortnox.NET.csproj
@@ -2,8 +2,8 @@
 
     <PropertyGroup>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>2.4.1</PackageVersion>
-        <Version>2.4.1</Version>
+        <PackageVersion>2.5.2</PackageVersion>
+        <Version>2.5.2</Version>
         <Title>Fortnox API SDK</Title>
         <Authors>Zenta AB</Authors>
         <Description>.NET bindings for the Fortnox API.</Description>

--- a/Fortnox.NET/Models/Assets/Asset.cs
+++ b/Fortnox.NET/Models/Assets/Asset.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using FortnoxNET.Utils;
 using Newtonsoft.Json;
@@ -28,9 +29,9 @@ namespace FortnoxNET.Models.Assets
         public string DepreciationMethod { get; set; }
         public double? AcquisitionValue { get; set; }
         public double? DepreciateToResidualValue { get; set; }
-        public string AcquisitionDate { get; set; }
-        public string AcquisitionStart { get; set; }
-        public string DepreciationFinal { get; set; }
+        public DateTime? AcquisitionDate { get; set; }
+        public DateTime? AcquisitionStart { get; set; }
+        public DateTime? DepreciationFinal { get; set; }
         [JsonReadOnly]
         public string DepreciatedTo { get; set; }
         [JsonReadOnly]

--- a/Fortnox.NET/Models/Assets/History.cs
+++ b/Fortnox.NET/Models/Assets/History.cs
@@ -1,4 +1,5 @@
 using FortnoxNET.Utils;
+using System;
 
 namespace FortnoxNET.Models.Assets
 {
@@ -7,7 +8,7 @@ namespace FortnoxNET.Models.Assets
         [JsonReadOnly]
         public int Id { get; set; }
         [JsonReadOnly]
-        public string Date { get; set; }
+        public DateTime Date { get; set; }
         [JsonReadOnly]
         public int EventId { get; set; }
         [JsonReadOnly]

--- a/Fortnox.NET/Models/Assets/WriteUpOrDownAsset.cs
+++ b/Fortnox.NET/Models/Assets/WriteUpOrDownAsset.cs
@@ -10,6 +10,6 @@ namespace FortnoxNET.Models.Assets
 
         public string Comment { get; set; }
 
-        public string Date { get; set; }
+        public DateTime Date { get; set; }
     }
 }

--- a/Fortnox.NET/Models/Order/Order.cs
+++ b/Fortnox.NET/Models/Order/Order.cs
@@ -17,32 +17,32 @@ namespace FortnoxNET.Models.Order
         [JsonProperty(PropertyName = "@urlTaxReductionList")]
         public string UrlTaxReductionList { get; set; }
 
-        public float AdministrationFee { get; set; }
+        public float? AdministrationFee { get; set; }
 
         [JsonReadOnly]
-        public float AdministrationFeeVAT { get; set; }
+        public float? AdministrationFeeVAT { get; set; }
 
         public string Address1 { get; set; }
 
         public string Address2 { get; set; }
 
         [JsonReadOnly]
-        public float BasisTaxReduction { get; set; }
+        public float? BasisTaxReduction { get; set; }
 
         [JsonReadOnly]
-        public bool Cancelled { get; set; }
+        public bool? Cancelled { get; set; }
 
         public string City { get; set; }
 
         public string Comments { get; set; }
 
         [JsonReadOnly]
-        public float ContributionPercent { get; set; }
+        public float? ContributionPercent { get; set; }
 
         [JsonReadOnly]
-        public float ContributionValue { get; set; }
+        public float? ContributionValue { get; set; }
 
-        public bool CopyRemarks { get; set; }
+        public bool? CopyRemarks { get; set; }
 
         public string Country { get; set; }
 
@@ -78,29 +78,29 @@ namespace FortnoxNET.Models.Order
 
         public string ExternalInvoiceReference2 { get; set; }
 
-        public float Freight { get; set; }
+        public float? Freight { get; set; }
 
         [JsonReadOnly]
         public float FreightVAT { get; set; }
 
         [JsonReadOnly]
-        public float Gross { get; set; }
+        public float? Gross { get; set; }
 
         [JsonReadOnly]
-        public bool HouseWork { get; set; }
+        public bool? HouseWork { get; set; }
 
         [JsonReadOnly]
-        public int InvoiceReference { get; set; }
+        public int? InvoiceReference { get; set; }
 
         [JsonReadOnly]
-        public float Net { get; set; }
+        public float? Net { get; set; }
 
-        public bool NotCompleted { get; set; }
+        public bool? NotCompleted { get; set; }
 
         public DateTime? OrderDate { get; set; }
 
         [JsonReadOnly]
-        public int OfferReference { get; set; }
+        public int? OfferReference { get; set; }
 
         public List<OrderRow> OrderRows { get; set; }
 
@@ -125,10 +125,10 @@ namespace FortnoxNET.Models.Order
         public string Remarks { get; set; }
 
         [JsonReadOnly]
-        public float RoundOff { get; set; }
+        public float? RoundOff { get; set; }
 
         [JsonReadOnly]
-        public bool Sent { get; set; }
+        public bool? Sent { get; set; }
 
         [JsonReadOnly]
         public float? TaxReduction { get; set; }
@@ -138,12 +138,12 @@ namespace FortnoxNET.Models.Order
         public string TermsOfPayment { get; set; }
 
         [JsonReadOnly]
-        public float Total { get; set; }
+        public float? Total { get; set; }
 
         [JsonReadOnly]
-        public float TotalVAT { get; set; }
+        public float? TotalVAT { get; set; }
 
-        public bool VATIncluded { get; set; }
+        public bool? VATIncluded { get; set; }
 
         public string WayOfDelivery { get; set; }
 

--- a/Fortnox.NET/Models/Order/OrderRow.cs
+++ b/Fortnox.NET/Models/Order/OrderRow.cs
@@ -6,43 +6,43 @@ namespace FortnoxNET.Models.Order
     [JsonConverter(typeof(CustomJsonConverter))]
     public class OrderRow
     {
-        public int AccountNumber { get; set; }
+        public int? AccountNumber { get; set; }
 
         public string ArticleNumber { get; set; }
 
         [JsonReadOnly]
-        public float ContributionPercent { get; set; }
+        public float? ContributionPercent { get; set; }
 
         [JsonReadOnly]
-        public float ContributionValue { get; set; }
+        public float? ContributionValue { get; set; }
 
         public string CostCenter { get; set; }
 
-        public float DeliveredQuantity { get; set; }
+        public float? DeliveredQuantity { get; set; }
 
         public string Description { get; set; }
 
-        public float Discount { get; set; }
+        public float? Discount { get; set; }
 
         public string DiscountType { get; set; }
 
-        public bool HouseWork { get; set; }
+        public bool? HouseWork { get; set; }
 
         public int? HouseWorkHoursToReport { get; set; }
 
         public string HouseWorkType { get; set; }
 
-        public float OrderedQuantity { get; set; }
+        public float? OrderedQuantity { get; set; }
 
-        public float Price { get; set; }
+        public float? Price { get; set; }
 
         public string Project { get; set; }
 
         [JsonReadOnly]
-        public float Total { get; set; }
+        public float? Total { get; set; }
 
         public string Unit { get; set; }
 
-        public float VAT { get; set; }
+        public float? VAT { get; set; }
     }
 }

--- a/Fortnox.NET/Models/Order/OrderRow.cs
+++ b/Fortnox.NET/Models/Order/OrderRow.cs
@@ -28,7 +28,7 @@ namespace FortnoxNET.Models.Order
 
         public bool HouseWork { get; set; }
 
-        public int HouseWorkHoursToReport { get; set; }
+        public int? HouseWorkHoursToReport { get; set; }
 
         public string HouseWorkType { get; set; }
 


### PR DESCRIPTION
### Description
Previously dates has been an issue within the system often preventing users from the executing the following code due to invalid date formatting:
```CSharp
var myOrder = await CreateFortnoxOrder(...);
// Do stuff
await UpdateMyFortnoxOrder(myOrder);
```

This should resolve that problem. I also made changes to the Order tests and Asset tests to make them run green again.

### Checklist
- [X] Code compiles correctly
- [X] Created tests which fail without the change (if possible)
- [X] Extended the README / documentation, if necessary