### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/Fortnox.NET.Tests/Fortnox.NET.Tests/Fortnox.NET.Tests.csproj
+++ b/Fortnox.NET.Tests/Fortnox.NET.Tests/Fortnox.NET.Tests.csproj
@@ -7,14 +7,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.4" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.4" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.4" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.4" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.17" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.17" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.17" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.17" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-        <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+        <PackageReference Include="MSTest.TestAdapter" Version="2.2.1" />
+        <PackageReference Include="MSTest.TestFramework" Version="2.2.1" />
+        <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
         <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
     </ItemGroup>
 


### PR DESCRIPTION
Hi@brokenprogrammer, I found an issue in the Fortnox.NET.Tests.csproj:

Packages Microsoft.Extensions.Configuration.Binder v3.1.4, Microsoft.Extensions.Configuration.EnvironmentVariables v3.1.4, Microsoft.Extensions.Configuration.UserSecrets v3.1.4, Microsoft.Extensions.Logging.Abstractions v3.1.4, MSTest.TestAdapter v1.4.0, MSTest.TestFramework v1.4.0 and Newtonsoft.Json v9.0.1 transitively introduce 114 dependencies into fortnox.NET’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/fortnox-NET.html)), while Microsoft.Extensions.Configuration.Binder v3.1.17, Microsoft.Extensions.Configuration.EnvironmentVariables v3.1.17, Microsoft.Extensions.Configuration.UserSecrets v3.1.17, Microsoft.Extensions.Logging.Abstractions v3.1.17, MSTest.TestAdapter v2.2.1, MSTest.TestFramework v2.2.1 and Newtonsoft.Json v12.0.2 can only introduce 79 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/fortnox-NET_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose